### PR TITLE
Fix for #7: remove jekyll-assets as a hard dependency

### DIFF
--- a/lib/jekyll/pdf/liquid/tags/jekyll-assets.rb
+++ b/lib/jekyll/pdf/liquid/tags/jekyll-assets.rb
@@ -1,4 +1,5 @@
-try_require "jekyll-assets" do
+begin
+  require 'jekyll-assets'
 
   module Jekyll
     module PDF
@@ -42,5 +43,5 @@ try_require "jekyll-assets" do
   Jekyll::PDF::AssetsTag::AcceptableTags.each do |tag|
     Liquid::Template.register_tag tag, Jekyll::PDF::AssetsTag
   end
-
+rescue LoadError
 end

--- a/lib/jekyll/pdf/liquid/tags/jekyll-assets.rb
+++ b/lib/jekyll/pdf/liquid/tags/jekyll-assets.rb
@@ -43,5 +43,6 @@ begin
   Jekyll::PDF::AssetsTag::AcceptableTags.each do |tag|
     Liquid::Template.register_tag tag, Jekyll::PDF::AssetsTag
   end
-rescue LoadError
+rescue LoadError => e
+  raise unless e.message =~ /jekyll-assets/
 end


### PR DESCRIPTION
`try_require` is a jekyll-assets method. Using jekyll-pdf without jekyll-assets will error because of this. This PR has the same intended behaviour but won't error if jekyll-assets isn't installed.