### PR TITLE
In fix_relative_paths, prepend site.source instead of site.dest.

### DIFF
--- a/lib/jekyll/pdf/helper.rb
+++ b/lib/jekyll/pdf/helper.rb
@@ -2,7 +2,11 @@ module Jekyll
   module PDF
     module Helper
       def fix_relative_paths
-        output.gsub!(/(href|src)=(['"])\/([^\/"']([^\"']*|[^"']*))?['"]/, "\\1=\\2file://#{site.dest}/\\3\\2") if output != nil
+        if site.baseurl != nil
+	  output.gsub!(/(href|src)=(['"])#{Regexp.escape(site.baseurl)}\/([^\/"']([^\"']*|[^"']*))?['"]/, "\\1=\\2file://#{site.source}/\\3\\2") if output != nil
+	else
+          output.gsub!(/(href|src)=(['"])\/([^\/"']([^\"']*|[^"']*))?['"]/, "\\1=\\2file://#{site.source}/\\3\\2") if output != nil
+	end
       end
     end
   end


### PR DESCRIPTION
This eliminates the need to run jekyll twice when buiding a
PDF and a local css or image file has been updated since those
may not have been updated in _site before the PDF is generated.

Also strip off site.baseurl if it is set, otherwise PDF generation
will fail.  The baseurl is the path to the dest directory as seen
from an external web server.