### PR TITLE
Fix #20: remove broken gem reference

### DIFF
--- a/jekyll-pdf.gemspec
+++ b/jekyll-pdf.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "wkhtmltopdf-installer", "~> 0.12"
   spec.add_runtime_dependency "pdfkit", "~> 0.8"
-  spec.add_runtime_dependency "digest", "~> 0"
   spec.add_runtime_dependency "jekyll", ">= 2.0", "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
The digest gem is provided by Ruby and in addition the name is reserved in the rubygems namespace, thus breaking the gemset. Fixes #20 